### PR TITLE
Add styled layout with elegant palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Site élégant</title>
+  <link rel="stylesheet" href="styles/main.css" />
+</head>
+<body>
+  <nav>
+    <ul>
+      <li><a href="#">Accueil</a></li>
+      <li><a href="#">Services</a></li>
+      <li><a href="#">Contact</a></li>
+    </ul>
+  </nav>
+
+  <section>
+    <h1>Bienvenue</h1>
+    <p>Exemple de section stylisée avec une typographie élégante et une palette de tons dorés.</p>
+    <button>En savoir plus</button>
+  </section>
+</body>
+</html>

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,0 +1,68 @@
+@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Source+Sans+Pro:wght@300;400;600&display=swap');
+
+:root {
+  --color-background: #f5f4f0;
+  --color-primary: #d4af37;
+  --color-secondary: #333333;
+  --color-accent: #e5c07b;
+}
+
+body {
+  font-family: 'Source Sans Pro', sans-serif;
+  background-color: var(--color-background);
+  color: var(--color-secondary);
+  margin: 0;
+  line-height: 1.6;
+}
+
+h1, h2, h3 {
+  font-family: 'Playfair Display', serif;
+}
+
+nav {
+  background-color: var(--color-primary);
+  padding: 1rem;
+}
+
+nav ul {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+
+nav a {
+  color: #ffffff;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+nav a:hover {
+  text-decoration: underline;
+}
+
+section {
+  padding: 2rem;
+  background-color: #ffffff;
+  margin: 1rem auto;
+  max-width: 800px;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+button {
+  background-color: var(--color-primary);
+  border: none;
+  color: #ffffff;
+  padding: 0.5rem 1rem;
+  font-family: inherit;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background-color 0.3s;
+}
+
+button:hover {
+  background-color: var(--color-secondary);
+}
+


### PR DESCRIPTION
## Summary
- add `styles/main.css` with a golden-toned palette, Google Fonts import, and styling for navigation, sections, and buttons
- introduce `index.html` linking the new stylesheet and showcasing the styled interface

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e3241ee8483209cd656e3b073774b