### PR TITLE
Add booking form and validation script

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Prendre rendez-vous</title>
+</head>
+<body>
+  <section id="booking">
+    <h2>Prendre rendez-vous</h2>
+    <form id="booking-form">
+      <label for="name">Nom</label>
+      <input type="text" id="name" name="name" required>
+
+      <label for="email">Email</label>
+      <input type="email" id="email" name="email" required>
+
+      <label for="phone">Téléphone</label>
+      <input type="tel" id="phone" name="phone" required>
+
+      <label for="date">Date</label>
+      <input type="date" id="date" name="date" required>
+
+      <label for="time">Heure</label>
+      <input type="time" id="time" name="time" required>
+
+      <button type="submit">Envoyer</button>
+    </form>
+  </section>
+
+  <script src="scripts/booking.js"></script>
+</body>
+</html>

--- a/scripts/booking.js
+++ b/scripts/booking.js
@@ -1,0 +1,41 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('booking-form');
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const formData = {
+      name: form.name.value.trim(),
+      email: form.email.value.trim(),
+      phone: form.phone.value.trim(),
+      date: form.date.value,
+      time: form.time.value
+    };
+
+    // Basic validation
+    for (const [key, value] of Object.entries(formData)) {
+      if (!value) {
+        alert('Veuillez remplir tous les champs.');
+        return;
+      }
+    }
+
+    // Prepare server integration
+    try {
+      const response = await fetch('/api/book', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(formData)
+      });
+
+      if (response.ok) {
+        alert('Votre demande a été envoyée.');
+        form.reset();
+      } else {
+        alert('Une erreur est survenue.');
+      }
+    } catch (err) {
+      console.error(err);
+      alert("Impossible d'envoyer votre demande pour le moment.");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add appointment form to index.html
- implement simple client-side validation and placeholder server call

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e338572ec8320bc9e8bf3c8cc6f88