### PR TITLE
Add gallery section with grid layout and lightbox

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Salon de Coiffure</title>
+  <link rel="stylesheet" href="styles/main.css">
+</head>
+<body>
+  <h1>Bienvenue au Salon</h1>
+
+  <section id="galerie">
+    <h2>Galerie</h2>
+    <div class="gallery">
+      <img src="images/style1.jpg" alt="Coiffure 1">
+      <img src="images/style2.jpg" alt="Coiffure 2">
+      <img src="images/style3.jpg" alt="Coiffure 3">
+      <img src="images/style4.jpg" alt="Coiffure 4">
+    </div>
+  </section>
+
+  <script src="scripts/gallery.js"></script>
+</body>
+</html>

--- a/scripts/gallery.js
+++ b/scripts/gallery.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const images = document.querySelectorAll('.gallery img');
+
+  images.forEach((img) => {
+    img.addEventListener('click', () => {
+      const overlay = document.createElement('div');
+      overlay.className = 'lightbox';
+      const fullImg = document.createElement('img');
+      fullImg.src = img.src;
+      overlay.appendChild(fullImg);
+      overlay.addEventListener('click', () => overlay.remove());
+      document.body.appendChild(overlay);
+    });
+  });
+});

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,0 +1,28 @@
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.gallery img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.lightbox {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.lightbox img {
+  max-width: 90%;
+  max-height: 90%;
+}


### PR DESCRIPTION
## Summary
- add Galerie section in `index.html` that displays salon photos from the new `images/` directory
- style the gallery as a responsive grid and lightbox overlay in `styles/main.css`
- implement simple lightbox behavior in `scripts/gallery.js`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e33870e9c83209ca6e3ef9f5f0f20